### PR TITLE
Fix V3008

### DIFF
--- a/Fallout4Checklist/Entities/Armor.cs
+++ b/Fallout4Checklist/Entities/Armor.cs
@@ -13,9 +13,6 @@ namespace Fallout4Checklist.Entities
             QuestStages = new List<QuestStage>();
             Merchants = new List<Character>();
             WornByCharacters = new List<Character>();
-            Slots = new List<ArmorSlot>();
-            Effects = new List<ArmorEffect>();
-            QuestStages = new List<QuestStage>();
             ChecklistCollectedStatus = new List<ChecklistArmor>();
         }
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings: 

### V3008 

- The 'Slots' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 16, 11. Fallout4Checklist Armor.cs 16

- The 'Effects' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 17, 10. Fallout4Checklist Armor.cs 17

- The 'QuestStages' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 18, 13. Fallout4Checklist Armor.cs 18